### PR TITLE
Update Go to 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ pb:
 		--volume "$(shell pwd):/go/src/github.com/mercari/go-conference-2021-spring-office-hour" \
 		--workdir /go/src/github.com/mercari/go-conference-2021-spring-office-hour \
 		--rm \
-		golang:1.16.6-buster \
+		golang:1.17.0-bullseye \
 		make gen-proto
 
 .PHONY: gen-proto

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercari/go-conference-2021-spring-office-hour
 
-go 1.16
+go 1.17
 
 require (
 	github.com/110y/run v1.0.0
@@ -17,4 +17,20 @@ require (
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+)
+
+require (
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.0-20210816181553-5444fa50b93d // indirect
+	github.com/goccy/go-json v0.7.6 // indirect
+	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
+	github.com/lestrrat-go/blackmagic v1.0.0 // indirect
+	github.com/lestrrat-go/httpcc v1.0.0 // indirect
+	github.com/lestrrat-go/iter v1.0.1 // indirect
+	github.com/lestrrat-go/option v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	golang.org/x/crypto v0.0.0-20201217014255-9d1352758620 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/text v0.3.5 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	google.golang.org/genproto v0.0.0-20210617175327-b9e0b3197ced
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
-	gopkg.in/yaml.v2 v2.3.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -482,9 +482,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
-gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/platform/db/Dockerfile
+++ b/platform/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS builder
+FROM golang:1.17.0-bullseye AS builder
 
 ENV GO111MODULE=on
 ENV GOOS=linux

--- a/services/authority/Dockerfile
+++ b/services/authority/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS builder
+FROM golang:1.17.0-bullseye AS builder
 
 ENV GO111MODULE=on
 ENV GOOS=linux

--- a/services/authority/grpc/server.go
+++ b/services/authority/grpc/server.go
@@ -91,6 +91,11 @@ func (s *server) ListPublicKeys(ctx context.Context, _ *proto.ListPublicKeysRequ
 		return nil, status.Error(codes.Internal, "failed to create jwks")
 	}
 
+	if err = key.Set(jws.AlgorithmKey, jwa.RS256); err != nil {
+		s.log(ctx).Error(err, "failed to set the alg to the jwk")
+		return nil, status.Error(codes.Internal, "failed to create jwks")
+	}
+
 	set := jwk.NewSet()
 	set.Add(key)
 
@@ -119,7 +124,7 @@ func createAccessToken(sub string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to create jws headers: %w", err)
 	}
 
-	if err := headers.Set(jws.AlgorithmKey, jwa.RS256.String()); err != nil {
+	if err := headers.Set(jws.AlgorithmKey, jwa.RS256); err != nil {
 		return nil, fmt.Errorf("failed to set the alg key to the token: %w", err)
 	}
 

--- a/services/catalog/Dockerfile
+++ b/services/catalog/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS builder
+FROM golang:1.17.0-bullseye AS builder
 
 ENV GO111MODULE=on
 ENV GOOS=linux

--- a/services/customer/Dockerfile
+++ b/services/customer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS builder
+FROM golang:1.17.0-bullseye AS builder
 
 ENV GO111MODULE=on
 ENV GOOS=linux

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS builder
+FROM golang:1.17.0-bullseye AS builder
 
 ENV GO111MODULE=on
 ENV GOOS=linux

--- a/services/item/Dockerfile
+++ b/services/item/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-buster AS builder
+FROM golang:1.17.0-bullseye AS builder
 
 ENV GO111MODULE=on
 ENV GOOS=linux

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,5 +1,14 @@
 module github.com/mercari/go-conference-2021-spring-office-hour/tools
 
-go 1.16
+go 1.17
 
 require github.com/grpc-ecosystem/grpc-gateway/v2 v2.3.0
+
+require (
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/protobuf v1.4.3 // indirect
+	google.golang.org/genproto v0.0.0-20210224155714-063164c882e6 // indirect
+	google.golang.org/protobuf v1.25.1-0.20201208041424-160c7477e0e8 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+)


### PR DESCRIPTION
- Update Go to 1.17
- Add `alg` to `jwks`
    - regarding this update from `jwx`: https://github.com/lestrrat-go/jwx/releases/tag/v1.2.0